### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "3.3"
+  - "3.2"
+  - "2.7"
+  - "2.6"
+  - "2.5"
+  - "pypy"
+before_install:
+  - sudo apt-get install -qq libsnappy1 libsnappy-dev python-dev libffi-dev
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy  ]]; then pip install --use-mirrors cffi; fi
+install:
+  - pip install -e . --use-mirrors
+# command to run tests
+script:
+  - nosetests test_snappy.py
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy  ]]; then nosetests test_snappy_cffi.py; fi


### PR DESCRIPTION
You can see travis in action at https://travis-ci.org/quiver/python-snappy

Some notes :
- Python 3.0 and 3.1 is not available on travis
- cffi requires pypy 2.0>=, which is not available on travis, so pypy test fails
  (http://cffi.readthedocs.org/en/latest/#installation-and-status)
  If there's a workaround, please let me know.
- nose is installed by default on travis, so "pip install nose" step is not included.
