### PR TITLE
Use built-in snappy library if system-wide snappy is absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,9 @@
 build
 dist
 MANIFEST
-
+*.so
+deps
+*.egg-info
+.tox
+tmp/
+__pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "pypy"
+
+before_install:
+    - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then sudo apt-get install libsnappy-dev; fi
+
+install:
+    - pip install --use-mirrors tox
+
+script: TOXENV=py$(echo $TRAVIS_PYTHON_VERSION | tr -d . | sed 's/pypy/py/g') tox -v

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,16 @@
 include *.py AUTHORS README.rst *.h MANIFEST.in
+
+graft buildutils
+graft deps
+prune deps/snappy/testdata
+recursive-exclude deps/snappy Makefile Makefile.in aclocal.m4 autom4te.cache config.* configure depcomp install-sh libtool ltmain.sh
+recursive-exclude deps/snappy missing stamp-h? .deps .dirstamp .libs *.l[ao] *~
+
+global-exclude __pycache__/*
+global-exclude .deps/*
+global-exclude *.so
+global-exclude *.pyd
+global-exclude *.pyc
+global-exclude .git*
+global-exclude .DS_Store
+global-exclude .mailmap

--- a/buildutils/__init__.py
+++ b/buildutils/__init__.py
@@ -1,0 +1,1 @@
+from .commands import snappy_sdist, snappy_build_ext

--- a/buildutils/commands.py
+++ b/buildutils/commands.py
@@ -1,0 +1,107 @@
+import ast
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+
+from distutils import log
+from distutils.command.build_ext import build_ext
+from distutils.command.sdist import sdist
+from distutils.errors import DistutilsError
+
+from .utils import exec_process, makedirs, rmtree
+from .detect import detect_snappy
+
+
+def download_snappy(snappy_dir, snappy_version, snappy_url):
+    log.info('Downloading snappy...')
+    makedirs(snappy_dir)
+    url = snappy_url.format(version=snappy_version)
+    base_dir = tempfile.mkdtemp()
+    release = 'snappy-{version}'.format(version=snappy_version)
+    archive = '{release}.tar.gz'.format(release=release)
+    archive_path = os.path.join(base_dir, archive)
+    release_path = os.path.join(base_dir, release)
+    try:
+        exec_process(['wget', '-O', archive_path, url])
+        exec_process(['tar', '-xzf', archive_path, '-C', base_dir])
+        exec_process(['cp', '-RT', release_path, snappy_dir])
+    finally:
+        rmtree(base_dir)
+
+
+class snappy_build_ext(build_ext):
+    snappy_dir = os.path.join('deps', 'snappy')
+    snappy_version = '1.1.1'
+    snappy_url = 'https://snappy.googlecode.com/files/snappy-{version}.tar.gz'
+
+    user_options = build_ext.user_options
+    user_options.extend([
+        ("snappy-clean-compile", None, "Clean snappy tree before compilation"),
+        ("snappy-force-fetch", None, "Remove snappy (if present) and fetch it again"),
+        ("snappy-verbose-build", None, "Print output of snappy build process")
+    ])
+    boolean_options = build_ext.boolean_options
+    boolean_options.extend(["snappy-clean-compile", "snappy-force-fetch", "snappy-verbose-build"])
+
+    def initialize_options(self):
+        build_ext.initialize_options(self)
+        self.snappy_clean_compile = 0
+        self.snappy_force_fetch = 0
+        self.snappy_verbose_build = 0
+
+    def build_extensions(self):
+        self.force = self.snappy_force_fetch or self.snappy_clean_compile
+        use_builtin_snappy = False
+        if sys.platform != 'win32':
+            version = detect_snappy()
+            if version is None or version < (1, 0, 4):
+                self.snappy_lib = os.path.join(self.snappy_dir, '.libs', 'libsnappy.a')
+                self.get_snappy()
+                # Set compiler options
+                self.extensions[0].extra_objects.extend([self.snappy_lib])
+                self.compiler.add_include_dir(self.snappy_dir)
+                use_builtin_snappy = True
+        if not use_builtin_snappy:
+            self.extensions[0].libraries.append('snappy')
+        build_ext.build_extensions(self)
+
+    def get_snappy(self):
+        def build_snappy():
+            cppflags = '-fPIC'
+            env = os.environ.copy()
+            env['CPPFLAGS'] = ' '.join(x for x in (cppflags, env.get('CPPFLAGS', None)) if x)
+            log.info('Building snappy...')
+            exec_process(['sh', 'autogen.sh'], cwd=self.snappy_dir, env=env, silent=not self.snappy_verbose_build)
+            exec_process(['./configure'], cwd=self.snappy_dir, env=env, silent=not self.snappy_verbose_build)
+            exec_process(['make'], cwd=self.snappy_dir, env=env, silent=not self.snappy_verbose_build)
+        if self.snappy_force_fetch:
+            rmtree('deps')
+        if not os.path.exists(self.snappy_dir):
+            try:
+                download_snappy(self.snappy_dir, self.snappy_version, self.snappy_url)
+            except BaseException:
+                rmtree('deps')
+                raise
+            build_snappy()
+        else:
+            if self.snappy_clean_compile:
+                exec_process(['make', 'clean'], cwd=self.snappy_dir)
+                exec_process(['make', 'distclean'], cwd=self.snappy_dir)
+            if not os.path.exists(self.snappy_lib):
+                log.info('snappy needs to be compiled.')
+                build_snappy()
+            else:
+                log.info('No need to build snappy.')
+
+
+class snappy_sdist(sdist):
+    snappy_dir = os.path.join('deps', 'snappy')
+    snappy_version = snappy_build_ext.snappy_version
+    snappy_url = snappy_build_ext.snappy_url
+
+    def initialize_options(self):
+        sdist.initialize_options(self)
+        rmtree('deps')
+        download_snappy(self.snappy_dir, self.snappy_version, self.snappy_url)

--- a/buildutils/detect.py
+++ b/buildutils/detect.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import platform
+import shutil
+
+from distutils import ccompiler
+from distutils.sysconfig import customize_compiler
+from distutils.errors import CompileError
+
+from .utils import exec_process, tempdir
+
+
+def test_compilation(basedir, cfile):
+    """Test simple compilation with given settings"""
+    cc = ccompiler.new_compiler()
+    customize_compiler(cc)
+    efile, ext = os.path.splitext(os.path.basename(cfile))
+    cpreargs = lpreargs = None
+    if sys.platform == 'darwin':
+        # use appropriate arch for compiler
+        if platform.architecture()[0] == '32bit':
+            if platform.processor() == 'powerpc':
+                cpu = 'ppc'
+            else:
+                cpu = 'i386'
+            cpreargs = ['-arch', cpu]
+            lpreargs = ['-arch', cpu, '-undefined', 'dynamic_lookup']
+        else:
+            # allow for missing UB arch, since it will still work:
+            lpreargs = ['-undefined', 'dynamic_lookup']
+    objs = cc.compile([cfile],
+                      output_dir=basedir, extra_preargs=cpreargs)
+    cc.link_executable(objs, efile,
+                       output_dir=basedir, extra_preargs=lpreargs, target_lang="c++")
+    return os.path.join(basedir, efile)
+
+
+def detect_snappy():
+    """Compile, link & execute a test program."""
+    with tempdir() as basedir:
+        try:
+            efile = test_compilation(
+                basedir, os.path.join('buildutils', 'vers.cpp'))
+        except CompileError:
+            return None
+        stdout = exec_process(efile)
+        version = int(stdout)
+        major = (version & 0xff0000) >> 16
+        minor = (version & 0x00ff00) >> 8
+        patch = (version & 0x0000ff)
+        return (major, minor, patch)

--- a/buildutils/utils.py
+++ b/buildutils/utils.py
@@ -1,0 +1,56 @@
+import errno
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+
+from distutils.errors import DistutilsError
+
+
+def makedirs(path):
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(path) and os.access(path, os.R_OK | os.W_OK | os.X_OK):
+            return
+        raise
+
+
+def rmtree(path):
+    try:
+        shutil.rmtree(path)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+
+
+def exec_process(cmdline, silent=True, input=None, **kwargs):
+    """Execute a subprocess and returns the returncode, stdout buffer and stderr buffer.
+    Optionally prints stdout and stderr while running."""
+    try:
+        sub = subprocess.Popen(args=cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+        stdout, stderr = sub.communicate(input=input)
+        returncode = sub.returncode
+        if not silent:
+            sys.stdout.write(stdout)
+            sys.stderr.write(stderr)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            raise DistutilsError('"%s" is not present on this system' % cmdline[0])
+        else:
+            raise
+    if returncode != 0:
+        raise DistutilsError('Got return value %d while executing "%s", stderr output was:\n%s' % (returncode, " ".join(cmdline), stderr.decode("utf-8").rstrip("\n")))
+    return stdout
+
+
+@contextmanager
+def tempdir():
+    """Create and then remove temporary"""
+    dir = tempfile.mkdtemp()
+    try:
+        yield dir
+    finally:
+        rmtree(dir)

--- a/buildutils/vers.cpp
+++ b/buildutils/vers.cpp
@@ -1,0 +1,9 @@
+// check snappy version
+
+#include <iostream>
+#include "snappy-stubs-public.h"
+
+int main(int argc, char **argv){
+    std::cout << SNAPPY_VERSION;
+    return 0;
+}

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 
 version = '0.5'
 long_description = """
@@ -35,17 +38,21 @@ More details about Snappy library: http://code.google.com/p/snappy
 
 
 snappymodule = Extension('_snappy',
-                         libraries=['snappy'],
                          sources=['snappymodule.cc', 'crc32c.c'])
 
 ext_modules = [snappymodule]
-packages = ['.']
 install_requires = []
+cmdclass = {}
 
 if 'PyPy' in sys.version:
     from setuptools import setup
     ext_modules = []
     install_requires = ['cffi']
+else:
+    from buildutils import snappy_build_ext, snappy_sdist
+    cmdclass = {'build_ext': snappy_build_ext,
+                'sdist': snappy_sdist}
+
 
 setup(
     name='python-snappy',
@@ -77,6 +84,6 @@ setup(
                  'Programming Language :: Python :: 3.2',
                  ],
     ext_modules = ext_modules,
-    packages = packages,
+    cmdclass = cmdclass,
     install_requires = install_requires
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = py26, py27, py32, py33, pypy
+
+[testenv]
+distribute = True
+sitepackages = False
+deps = nose
+commands = 
+    python setup.py build_ext --inplace
+    nosetests test_snappy \
+        --detailed-errors \
+        --verbose
+
+[testenv:pypy]
+basepython = pypy
+commands =
+    nosetests test_snappy \
+        --detailed-errors \
+        --verbose
+    nosetests test_snappy_cffi \
+        --detailed-errors \
+        --verbose


### PR DESCRIPTION
Now python-snappy can detect the absence of a system-wide snappy library and respond by building and linking to its own copy of the library. Also python-snappy will use its own copy if system library is older than 1.0.4. The python-snappy source distribution carries its own copy of the source code so that no network access is necessary for its install to complete successfully.

Limitations:

* windows not supported;
* pypy not supported;

Changes:

* include snappy source to python sdist and use it if system-wide version is absent;
* use tox and travis to run test suite for multiple interpreters, including py26, py27, py32, py33, pypy;