### PR TITLE
Allow python-snappy to be compiled in Windows

### DIFF
--- a/crc32c.h
+++ b/crc32c.h
@@ -53,7 +53,11 @@ crc_t crc_reflect(crc_t data, size_t data_len);
  *
  * \return     The initial crc value.
  *****************************************************************************/
+#ifdef _MSC_VER
+static __inline crc_t crc_init(void)
+#else
 static inline crc_t crc_init(void)
+#endif
 {
     return 0xffffffff;
 }
@@ -76,7 +80,11 @@ crc_t crc_update(crc_t crc, const unsigned char *data, size_t data_len);
  * \param crc  The current crc value.
  * \return     The final crc value.
  *****************************************************************************/
+#ifdef _MSC_VER
+static __inline crc_t crc_finalize(crc_t crc)
+#else
 static inline crc_t crc_finalize(crc_t crc)
+#endif
 {
     return crc ^ 0xffffffff;
 }


### PR DESCRIPTION
Since MSVC only allows the inline keyword to be used on .cpp files, it is needed to check if _MSC_VER is defined, so it can be detected if the compiler is MSVC and use the vendor-specific __inline keyword instead. Without this change, the only way to compile python-snappy is to download the source code, make the change and compile/install manually.
