### PR TITLE
Update setup.py to expose only `snappy` and `_snappy` as top-level mo…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@
 import sys
 from distutils.core import setup, Extension
 
-version = '0.5.1'
+version = '0.5.2'
 long_description = """
 Python bindings for the snappy compression library from Google.
 
@@ -39,7 +39,8 @@ snappymodule = Extension('_snappy',
                          sources=['snappymodule.cc', 'crc32c.c'])
 
 ext_modules = [snappymodule]
-packages = ['.']
+packages = ['snappy']
+package_dir = {'snappy': ''}
 install_requires = []
 
 if 'PyPy' in sys.version:
@@ -75,5 +76,6 @@ setup(
                  ],
     ext_modules = ext_modules,
     packages = packages,
+    package_dir = package_dir,
     install_requires = install_requires
 )


### PR DESCRIPTION
When trying to add this package as a dependency, our build tool began giving strange errors: it thought that this package would meet all requirements.

This was because the earlier `setup.py` had `packages = ['.']`, implying that this package provided everything. This PR updates `setup.py` to explicitly expose only `snappy` as a package provided by this library.