### PR TITLE
inline workaround

### DIFF
--- a/snappy/crc32c.h
+++ b/snappy/crc32c.h
@@ -19,6 +19,12 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#if defined(_MSC_VER) && !defined(__cplusplus)   /* Visual Studio */
+#ifndef inline
+#define inline __inline  /* Visual C is not C99, but supports some kind of inline */
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Add a workaround to the C headers to make it possible to compile with old versions of MSVC. Along with [msinttypes](https://code.google.com/archive/p/msinttypes/), this makes it possible to build on old versions of MSVC needed for Python 2.7 on Windows. (Example of it working: https://github.com/conda-forge/python-snappy-feedstock/pull/10.)

Fixes https://github.com/andrix/python-snappy/issues/48.