### PR TITLE
fix imports for python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ build
 dist
 MANIFEST
 __pycache__
-
+*.so
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  ],
-    ext_modules = ext_modules,
-    packages = packages,
-    install_requires = install_requires
+    ext_modules=ext_modules,
+    packages=packages,
+    install_requires=install_requires
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 
 version = '0.5.2'
 long_description = """

--- a/snappy/__init__.py
+++ b/snappy/__init__.py
@@ -1,4 +1,4 @@
-from snappy import (
+from .snappy import (
 	compress,
 	decompress,
 	uncompress,

--- a/snappy/__main__.py
+++ b/snappy/__main__.py
@@ -1,4 +1,4 @@
-from snappy import stream_compress, stream_decompress
+from .snappy import stream_compress, stream_decompress
 
 def cmdline_main():
     """This method is what is run when invoking snappy via the commandline.

--- a/snappy/snappy.py
+++ b/snappy/snappy.py
@@ -44,11 +44,11 @@ import sys
 import struct
 
 try:
-    from _snappy import UncompressError, compress, decompress, \
-                        isValidCompressed, uncompress, _crc32c
+    from ._snappy import UncompressError, compress, decompress, \
+                         isValidCompressed, uncompress, _crc32c
 except ImportError:
-    from snappy_cffi import UncompressError, compress, decompress, \
-                            isValidCompressed, uncompress, _crc32c
+    from .snappy_cffi import UncompressError, compress, decompress, \
+                             isValidCompressed, uncompress, _crc32c
 
 _CHUNK_MAX = 65536
 _STREAM_TO_STREAM_BLOCK_SIZE = _CHUNK_MAX


### PR DESCRIPTION
#54 apparently wasn't tested on python 3; it tries to do some relative import stuff, which doesn't work. This fixes it.

I also noticed that `setup.py` uses `install_requires` but doesn't actually use `setuptools.setup`, so that line only does anything if you're installing with `pip` and not if you're using `setup.py` directly. I changed it to use `setuptools` if available.