### PR TITLE
Run tests under Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - pytest 
+  - pytest test_snappy.py
   - nosetests test_snappy.py
   - if [[ $TRAVIS_PYTHON_VERSION == pypy  ]]; then nosetests test_snappy_cffi.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - pytest test_snappy.py
+  #- pytest test_snappy.py
   - nosetests test_snappy.py
   - if [[ $TRAVIS_PYTHON_VERSION == pypy  ]]; then nosetests test_snappy_cffi.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - libsnappy-dev
 install:
   #- pip install python-snappy
-  - pip install -e
+  - pip install -e .
   - pip install cffi flake8 nose2 pytest
 before_script:
     # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,22 @@ python:
   - "3.6"
   - "pypy"
   - "pypy3"
+matrix:
+  allow_failures:
+    - python: pypy3
 addons:
   apt:
     packages:
-    - libsnappy-dev
+      - libsnappy-dev
 install:
   #- pip install python-snappy
   - pip install -e .
   - pip install cffi flake8 nose2 pytest
 before_script:
-    # stop the build if there are Python syntax errors or undefined names
-    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   #- pytest test_snappy.py
   - nosetests test_snappy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 install:
   #- pip install python-snappy
   - pip install -e
-  - pip install flake8 nose2 pytest
+  - pip install cffi flake8 nose2 pytest
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+  - "pypy3"
+addons:
+  apt:
+    packages:
+    - libsnappy-dev
+install:
+  #- pip install python-snappy
+  - pip install -e
+  - pip install flake8 nose2 pytest
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - pytest 
+  - nosetests test_snappy.py
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy  ]]; then nosetests test_snappy_cffi.py; fi

--- a/snappy/snappy_cffi.py
+++ b/snappy/snappy_cffi.py
@@ -1,7 +1,14 @@
 from _snappy_cffi import ffi, lib
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
+
 class UncompressError(Exception):
     pass
+
 
 class SnappyBufferSmallError(Exception):
     pass


### PR DESCRIPTION
Another attempt at #17

The owner of the this repo would need to go to https://travis-ci.org/profile and flip the repository switch __on__ to enable free automated flake8 testing of each pull request.

flake8 testing of https://github.com/andrix/python-snappy on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./snappy/snappy_cffi.py:21:25: F821 undefined name 'unicode'
    if isinstance(data, unicode):
                        ^
./snappy/snappy_cffi.py:71:25: F821 undefined name 'unicode'
    if isinstance(data, unicode):
                        ^
2     F821 undefined name 'unicode'
```