### PR TITLE
do not display traceback when used in CLI

### DIFF
--- a/snappy/__main__.py
+++ b/snappy/__main__.py
@@ -82,10 +82,10 @@ def cmdline_main():
             sys.exit("Failed to get decompress function: {}".format(err))
         additional_args['start_chunk'] = read_chunk
 
-    try:
-        method(args.infile, args.outfile, **additional_args)
-    except Exception as err:
-        sys.exit("%s: %s" % (err.__class__.__name__, err))
+    method(args.infile, args.outfile, **additional_args)
 
 if __name__ == "__main__":
-    cmdline_main()
+    try:
+        cmdline_main()
+    except Exception as err:
+        sys.exit("%s: %s" % (err.__class__.__name__, err))

--- a/snappy/__main__.py
+++ b/snappy/__main__.py
@@ -82,8 +82,10 @@ def cmdline_main():
             sys.exit("Failed to get decompress function: {}".format(err))
         additional_args['start_chunk'] = read_chunk
 
-    method(args.infile, args.outfile, **additional_args)
-
+    try:
+        method(args.infile, args.outfile, **additional_args)
+    except Exception as err:
+        sys.exit("%s: %s" % (err.__class__.__name__, err))
 
 if __name__ == "__main__":
     cmdline_main()

--- a/snappy/__main__.py
+++ b/snappy/__main__.py
@@ -84,6 +84,7 @@ def cmdline_main():
 
     method(args.infile, args.outfile, **additional_args)
 
+
 if __name__ == "__main__":
     try:
         cmdline_main()


### PR DESCRIPTION
FIXES #67 

I'd probably prefer using
```
print("%s: %s" % (err.__class__.__name__, err))
sys.exit(1)
```
but I decided in favour of keeping consistent code.

Also I was not sure whether to catch a generic `Exception` or only `UncompressError`, but for my case any traceback in the output is unwanted.