### PR TITLE
Use explicit relative import of _snappy_cffi to support PyPy3, fixes #69

### DIFF
--- a/snappy/__init__.py
+++ b/snappy/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from .snappy import (
 	compress,
 	decompress,

--- a/snappy/__main__.py
+++ b/snappy/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import argparse
 import io
 import sys

--- a/snappy/hadoop_snappy.py
+++ b/snappy/hadoop_snappy.py
@@ -19,6 +19,7 @@ Expected usage like:
         assert fin1.read() == fin2.read()
 
 """
+from __future__ import absolute_import
 
 import struct
 

--- a/snappy/snappy.py
+++ b/snappy/snappy.py
@@ -39,6 +39,7 @@ Expected usage like:
     assert "some data" == snappy.uncompress(compressed)
 
 """
+from __future__ import absolute_import
 
 import sys
 import struct

--- a/snappy/snappy_cffi.py
+++ b/snappy/snappy_cffi.py
@@ -1,4 +1,4 @@
-from _snappy_cffi import ffi, lib
+from ._snappy_cffi import ffi, lib
 
 try:
     unicode        # Python 2

--- a/snappy/snappy_cffi.py
+++ b/snappy/snappy_cffi.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from ._snappy_cffi import ffi, lib
 
 try:

--- a/snappy/snappy_formats.py
+++ b/snappy/snappy_formats.py
@@ -5,6 +5,8 @@ get_decompress_function - returns stream decompress function for a current
 get_compress_function - returns compress function for a current format
     (specifed or default)
 """
+from __future__ import absolute_import
+
 from .snappy import (
     stream_compress, stream_decompress, check_format, UncompressError)
 from .hadoop_snappy import (


### PR DESCRIPTION
Module ``snappy_cffi.py`` used old-style relative import which was deprecated and is not support by python3, so python3 + cffi combination is broken which is the case of pypy3 and it's described in #69.