### PR TITLE
docs: fix simple typo, specifed -> specified

### DIFF
--- a/src/snappy/snappy_formats.py
+++ b/src/snappy/snappy_formats.py
@@ -3,7 +3,7 @@ ALL_SUPPORTED_FORMATS - list of supported formats
 get_decompress_function - returns stream decompress function for a current
     format (specified or autodetected)
 get_compress_function - returns compress function for a current format
-    (specifed or default)
+    (specified or default)
 """
 from __future__ import absolute_import
 


### PR DESCRIPTION
There is a small typo in src/snappy/snappy_formats.py.

Should read `specified` rather than `specifed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md