### PR TITLE
Find homebrew folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,10 @@ library_dirs, include_dirs = [], []
 if os.environ.get("CIBUILDWHEEL", False) and sys.version_info[:2] == (3, 9) and sys.platform =="darwin":
     library_dirs = ["/usr/local/lib/"]
     include_dirs = ["/usr/local/include/"]
+homebrew_prefix = os.environ.get("HOMEBREW_PREFIX")
+if homebrew_prefix:
+    library_dirs.append(os.path.join(homebrew_prefix, "lib"))
+    include_dirs.append(os.path.join(homebrew_prefix, "include"))
 
 
 snappymodule = Extension('snappy._snappy',


### PR DESCRIPTION
Hello,

Failing to find `snappy-c.h` on macos with error:
```
snappy/snappymodule.cc:32:10: fatal error: 'snappy-c.h' file not found
  #include <snappy-c.h>
           ^~~~~~~~~~~~
  1 error generated.
  error: command 'gcc' failed with exit status 1
```

My homebrew folder is `/opt/homebrew`, tried with the following change and worked fine. Let me know what you think.

To test it, just run as `pip install git+https://github.com/hugobranquinho/python-snappy@brew_prefix`

Thanks!