### PR TITLE
Doc to include CPPFLAGS for apple silicon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,3 +138,10 @@ Try this command if libstdc++ is deprecated
 ::
   
     $ CPPFLAGS="-I/usr/local/include -L/usr/local/lib -stdlib=libc++ " pip install python-snappy
+    
+
+Or this command in Apple Silicon:
+
+::
+  
+    $ CPPFLAGS="-I/opt/homebrew/include -L/opt/homebrew/lib" pip install python-snappy 


### PR DESCRIPTION
Home-brew installed to `/opt/homebrew` rather than `/usr/local` on Apple Silicon as [homebrew installation instructions](https://docs.brew.sh/Installation). This PR adds the `CPPFLAGS` for Apple Silicon where snappy is installed with `brew install snappy`.