### PR TITLE
Add type hints

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Archive sdist
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels ${{ matrix.os }}-${{ matrix.architecture }}
           path: dist/python-snappy*.tar.gz
 
   build:
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: wheels
+          name: wheels ${{ matrix.os }}-${{ matrix.architecture }}
 
   upload:
     runs-on: ubuntu-latest
@@ -122,7 +122,7 @@ jobs:
       - name: Download test data
         uses: actions/download-artifact@v4.1.7
         with:
-          name: wheels
+          name: wheels ${{ matrix.os }}-${{ matrix.architecture }}
       - name: Publish wheels to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
                  'Operating System :: MacOS :: MacOS X',
                  # 'Operating System :: Microsoft :: Windows', -- Not tested yet
                  'Operating System :: POSIX',
+                 'Typing :: Typed',
                  'Programming Language :: Python :: 3',
                  'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
@@ -75,4 +76,5 @@ setup(
     install_requires=install_requires,
     setup_requires=setup_requires,
     package_dir={'': 'src'},
+    package_data={'snappy': ['py.typed']}
 )


### PR DESCRIPTION
This adds type hints to the library, so tools such as mypy will be able to check usage (and won't complain about missing types when importing it).

Tested with Python 3.8

Notes:
1. I only added hints to what's defined in `__init__.py`.
2. For `stream_compress` and `stream_decompress` I defined generic inputs / outputs since the provided de/compressor class can convert between bytes and str. I tested such a class and it passed type checking. I'm sure the typing of that section can be improved, perhaps by using [Reader and Writer protocols instead of IO](https://discuss.python.org/t/simple-reader-and-writer-protocols/61510), but this is beyond my very limited proficiency.