### PR TITLE
Various small cleanup changes

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -41,7 +41,7 @@ jobs:
         run: pytest --verbose test_snappy.py
 
       - name: Archive sdist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist/python-snappy*.tar.gz

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -52,19 +52,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-12, windows-2019]
-        architecture: ['x64']
+        architecture: ["x64"]
         linux_archs: ["auto s390x"]
         include:
           - os: windows-2019
-            architecture: 'x86'
+            architecture: "x86"
             skip: "*2*win* *win_amd64"
             environment_windows: INCLUDE="C:/Program Files (x86)/Snappy/include" LIB="C:/Program Files (x86)/Snappy/lib"
           - os: windows-2019
-            architecture: 'x64'
+            architecture: "x64"
             skip: "*2*win* *win32"
             environment_windows: INCLUDE="C:/Program Files/Snappy/include" LIB="C:/Program Files/Snappy/lib"
           - os: ubuntu-20.04
-            architecture: 'x64'
+            architecture: "x64"
             linux_archs: aarch64 ppc64le
 
     name: Python ${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
-        
+
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v1.0.2
@@ -108,7 +108,7 @@ jobs:
         run: |
           python -m pip wheel -w ./wheelhouse .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: wheels
@@ -116,7 +116,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     name: upload wheels
-    needs: ['sdist', 'build']
+    needs: ["sdist", "build"]
     if: startsWith(github.ref, 'refs/tags/0.')
     steps:
       - name: Download test data

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ python-snappy
 
 Python library for the snappy compression library from Google.
 This library is distributed under the New BSD License
-(http://www.opensource.org/licenses/bsd-license.php).
+(https://opensource.org/license/bsd-3-clause).
 
 Dependencies
 ============

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Dependencies
 Install
 =======
 
-Install it from PyPi:
+Install it from PyPI:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -65,4 +65,4 @@ You can get help by running
 
 
 Snappy - compression library from Google (c)
- http://google.github.io/snappy
+ https://google.github.io/snappy

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
                  'Programming Language :: Python :: 3.12',
                  ],
     packages=packages,
+    python_requires=">=3.8",
     install_requires=install_requires,
     setup_requires=setup_requires,
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ version = '0.7.1'
 long_description = """
 Python bindings for the snappy compression library from Google.
 
-More details about Snappy library: http://google.github.io/snappy
+More details about Snappy library: https://google.github.io/snappy
 """
 
 packages = ['snappy']
@@ -47,7 +47,7 @@ setup(
     version=version,
     author='Andres Moreira',
     author_email='andres@andresmoreira.com',
-    url='http://github.com/intake/python-snappy',
+    url='https://github.com/intake/python-snappy',
     description='Python library for the snappy compression library from Google',
     long_description=long_description,
     keywords='snappy, compression, google',

--- a/src/snappy/snappy.py
+++ b/src/snappy/snappy.py
@@ -41,8 +41,6 @@ Expected usage like:
 """
 from __future__ import absolute_import
 
-import struct
-
 import cramjam
 
 _CHUNK_MAX = 65536

--- a/src/snappy/snappy.py
+++ b/src/snappy/snappy.py
@@ -298,8 +298,8 @@ def stream_decompress(src,
     support the read method, and 'dst' should support the write method.
 
     The default blocksize is good for almost every scenario.
-    :param decompressor_cls: class that implements `decompress` method like
-        StreamDecompressor in the module
+    :param decompressor_cls: class that implements `decompress` and
+        `flush` methods like StreamDecompressor in the module
     :param start_chunk: start block of data that have already been read from
         the input stream (to detect the format, for example)
     """

--- a/test_snappy.py
+++ b/test_snappy.py
@@ -31,7 +31,6 @@ import platform
 import sys
 import random
 import snappy
-import struct
 from unittest import TestCase
 
 

--- a/test_snappy.py
+++ b/test_snappy.py
@@ -69,12 +69,6 @@ class SnappyCompressionTest(TestCase):
         self.assertRaises(snappy.UncompressError, snappy.uncompress,
                           "hoa".encode('utf-8'))
 
-    if sys.version_info[0] == 2:
-        def test_unicode_compress(self):
-            text = "hello unicode world!".decode('utf-8')
-            compressed = snappy.compress(text)
-            self.assertEqual(text, snappy.uncompress(compressed))
-
     def test_decompress(self):
         # decompress == uncompress, just to support compatibility with zlib
         text = "hello world!".encode('utf-8')


### PR DESCRIPTION
* **Remove unused imports** - `struct` was imported but unused.
* **Mention required 'flush' in stream_decompress documentation** - the provided class must implement it, but it wasn't documented.
* **Switch to HTTPS URLs in documentation**
* **Fix PyPI capitalization in README**
* **Remove Python 2 test** - version no longer supported
* **Enforce minimum Python version** - now packaging tools will return an error if the user doesn't have 3.8+
* **Link to correct BSD license**  - the README and the license is the 3-clause "New BSD License", but the link led to the 2-clause BSD license
